### PR TITLE
fix: replace Bitnami images with open Soldevelo equivalents

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,7 +106,7 @@ services:
       interval: 30s
 
   kafka:
-    image: docker.io/bitnami/kafka:3.9
+    image: docker.io/soldevelo/kafka:3.9
     container_name: cs_kafka
     networks:
       - ba-mojaloop-net
@@ -139,7 +139,7 @@ services:
     container_name: cs_kafka-provisioning
     networks:
       - ba-mojaloop-net
-    image: docker.io/bitnami/kafka:3.9
+    image: docker.io/soldevelo/kafka:3.9
     depends_on:
       - kafka
     volumes:


### PR DESCRIPTION
## Fix: replace restricted Bitnami images

Since **August 28, 2025**, Bitnami distributes most container images only through paid VMware Tanzu subscriptions. Pulling them without a valid subscription may fail silently or return stale image layers, which is a supply-chain reliability concern.

This PR replaces every affected reference with the corresponding image from [SolDevelo/containers](https://github.com/SolDevelo/containers) - a community fork of `bitnami/containers` that publishes identical, freely accessible images to Docker Hub under the `soldevelo/` namespace.

No configuration changes beyond the image tag itself are required.

## Replaced references

- `bitnami/kafka:3.9` → [`soldevelo/kafka:3.9`](https://hub.docker.com/r/soldevelo/kafka)